### PR TITLE
Fix bug when episode has no files

### DIFF
--- a/download.rb
+++ b/download.rb
@@ -170,7 +170,7 @@ module ElixirSips
 
       # Download the files.
       puts "Downloading to #{title_dir}"
-      episode[:files].each do |file|
+      (episode[:files]||[]).each do |file|
         file_dir = "#{title_dir}/#{file[:file_name]}"
 
         if not File.exist? file_dir


### PR DESCRIPTION
Hello!

Episode 161 has no files, ergo in line 173 of download.rb this code fails:

``` ruby
      episode[:files].each do |file|
```

Because episode[:files] is nil, which leads to `nil doesn't have method "each"`

This commit solves the issue.
Thanks!
